### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/sudo-elia/api-trenitalia/security/code-scanning/1](https://github.com/sudo-elia/api-trenitalia/security/code-scanning/1)

To fix the issue, add a `permissions` block to the `build` job to explicitly limit the `GITHUB_TOKEN` permissions. Since the `build` job only needs to read the repository contents (e.g., to install dependencies and build the project), the `contents: read` permission is sufficient. This change ensures that the job does not inadvertently gain unnecessary write permissions.

The `permissions` block should be added under the `build` job definition, at the same level as `runs-on`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
